### PR TITLE
Fix typo in Serialization example

### DIFF
--- a/Home.md
+++ b/Home.md
@@ -75,7 +75,7 @@ message Block {
 ```
 Block.Builder block = Block.newBuilder()
     .setTransactions(transactions)
-    .setBlockHeader(blochHeader)
+    .setBlockHeader(blockHeader)
     .build();
     
 byte[] blockData = block.toByteArray();


### PR DESCRIPTION
Fix typo in example code

Typo: `blochHeader`
Fix: `blockheader`